### PR TITLE
msr: Adding check for kernel module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msru"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "Larry Dewey <larry.dewey@amd.com>"]
 edition = "2021"
 rust-version = "1.59"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following line to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-msru = "0.1.0"
+msru = "0.2.0"
 ```
 
 ## Usage
@@ -19,7 +19,9 @@ msru = "0.1.0"
 use msru::Msr;
 
 // X86_64 SYSCFG MSR
-let msr: Msr = Msr::new(0xC0010010, 0);
+let msr: Msr = Msr::new(0xC0010010, 0)?;
+
+let raw_value: u64 = msr.read()?;
 
 // ...
 ```


### PR DESCRIPTION
Previously, if the kernel module was not present, this was silently returning an empty file-handle. When the MSR kernel module is not present, we want to make sure a specific error is returned letting the user know that it is not present. For now, we are checking this by looking if the device-file is present.